### PR TITLE
feat(aptup): explicitly tell to only list the services that need to be restarted

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           cache: poetry
 
       - name: Install deps
-        run: poetry install
+        run: poetry install --no-root
 
       - name: Lint code
         run: poetry run poe lint

--- a/roles/aptup/tasks/next_release.yml
+++ b/roles/aptup/tasks/next_release.yml
@@ -16,6 +16,7 @@
   register: aptup_full
   environment:
     DEBIAN_FRONTEND: noninteractive
+    NEEDRESTART_MODE: l # Only list the services that need to be restarted
 
 - name: Show full-upgrade result
   ansible.builtin.debug:

--- a/roles/aptup/tasks/upgrade.yml
+++ b/roles/aptup/tasks/upgrade.yml
@@ -26,6 +26,7 @@
   register: aptup_dist
   environment:
     DEBIAN_FRONTEND: noninteractive
+    NEEDRESTART_MODE: l # Only list the services that need to be restarted
 
 - name: Show dist-upgrade result
   ansible.builtin.debug:


### PR DESCRIPTION
See: https://discourse.ubuntu.com/t/needrestart-changes-in-ubuntu-24-04-service-restarts/44671

> The tool now behaves the same in both cases by directly restarting the affected services (as was previously the default in the interactive case).